### PR TITLE
RailsModel.commit refeito

### DIFF
--- a/app/assets/javascripts/backbone.rails_store.js.coffee
+++ b/app/assets/javascripts/backbone.rails_store.js.coffee
@@ -367,8 +367,9 @@ class Backbone.RailsStore
     commitData = {}
     _.each @_changedModels, (models, modelType) =>
       _.each models, (model) =>
-        commitData[modelType] = {railsClass: model.railsClass, data: []} unless commitData[modelType]
-        commitData[modelType].data.push(model.toJSON())
+        if model.markedForSave
+          commitData[modelType] = {railsClass: model.railsClass, data: []} unless commitData[modelType]
+          commitData[modelType].data.push(model.toJSON())
 
     destroyData = {}
     _.each @_deletedModels, (model) =>
@@ -887,6 +888,15 @@ class Backbone.RailsModel extends Backbone.Model
     Internal store reference
   ###
   _store: null
+
+
+  ###
+    markedForSave - All models are marked to be sent in the next commit by default.
+
+    Useful when one wants to create a context to commit just some models while having
+    other models dirty in the store
+  ###
+  markedForSave: true
 
   ###
     belongsTo - Relations where reference resides in this object
@@ -1469,7 +1479,7 @@ class Backbone.RailsCollection extends Backbone.Collection
     else
       return super
 
-    throw "Invalid model type #{@store.getModelType(model)} for collection #{@}"
+    throw "Invalid model type #{@_store.getModelType(model)} for collection #{@}"
 
   _prepareModel: (attrs, options) ->
     if attrs instanceof Backbone.RailsModel

--- a/app/assets/javascripts/backbone.rails_store.js.coffee
+++ b/app/assets/javascripts/backbone.rails_store.js.coffee
@@ -755,13 +755,14 @@ class Backbone.RailsStore
             options.error(model.get('errors')) if options.error
             return
           options.success() if options.success
-          @_unblockCommits()
         catch e
           console.log(e)
           @trigger('comm:fatal', e)
           options.error() if options.error
-          @_unblockCommits()
           throw e
+        finally
+          @_unblockCommits()
+
       error: =>
         return if (@_abortingXhrs)
         options.error() if options.error

--- a/app/controllers/backbone_rails_store_controller.rb
+++ b/app/controllers/backbone_rails_store_controller.rb
@@ -445,7 +445,7 @@ class BackboneRailsStoreController < ApplicationController
       # TODO: in case model has been erased on server, notify
       ids = model_info[:ids] || []
       model_class = model_info[:railsClass]
-      server_models = acl_scoped_class(model_class, :read).where(:id => ids.uniq)
+      server_models = acl_scoped_class(model_class, :read).where(:id => ids.uniq).all
       models_eager = {:models => {}, :relations => {}}
       fill_eager_refresh model_class, server_models, models_eager
       resp_models[model_info[:railsClass]] = server_models

--- a/app/controllers/backbone_rails_store_controller.rb
+++ b/app/controllers/backbone_rails_store_controller.rb
@@ -244,12 +244,12 @@ class BackboneRailsStoreController < ApplicationController
                     else
                       #prevent attributions of not attr_accessible parameters
                       unless authorizer.deny?(attr_key)
-                        server_model[attr_key] = attr
+                        server_model.send(attr_key.to_s + '=', attr)
                       end
                     end
                   else
                     unless authorizer.deny?(attr_key)
-                      server_model[attr_key] = attr
+                      server_model.send(attr_key.to_s + '=', attr)
                     end
                   end
                 end

--- a/app/controllers/backbone_rails_store_controller.rb
+++ b/app/controllers/backbone_rails_store_controller.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 ###
 #  Copyright (C) 2013 - Raphael Derosso Pereira <raphaelpereira@gmail.com>
 #

--- a/app/controllers/backbone_rails_store_controller.rb
+++ b/app/controllers/backbone_rails_store_controller.rb
@@ -213,7 +213,7 @@ class BackboneRailsStoreController < ApplicationController
                 server_model = acl_scoped_class(klass, :write).find(model['id'])
                 raise_error_hash(klass, 'no write permission') unless server_model
               else
-                server_model = klass.constantize.new(model)
+                server_model = klass.constantize.new()
                 server_model.cid = model['cid']
                 new_models[model['cid']] = server_model
                 models_ids[key.to_sym] = {} unless models_ids[key.to_sym]
@@ -227,15 +227,19 @@ class BackboneRailsStoreController < ApplicationController
 #              raise_error(server_model) unless updated
 
               model.each do |attr_key, attr|
-                if attr_key.match(/.*_id$/)
-                  if attr.to_s().match(/c[[:digit:]]*/)
-                    set_after_create.push({
-                                              :model => server_model,
-                                              :railsClass => klass,
-                                              :key => key,
-                                              :attr  => attr_key,
-                                              :temp_id => attr
-                                          })
+                if server_model.respond_to? (attr_key.to_s + '=').to_sym
+                  if attr_key.match(/.*_id$/)
+                    if attr.to_s().match(/c[[:digit:]]*/)
+                      set_after_create.push({
+                                                :model => server_model,
+                                                :railsClass => klass,
+                                                :key => key,
+                                                :attr  => attr_key,
+                                                :temp_id => attr
+                                            })
+                    else
+                        server_model[attr_key] = attr
+                    end
                   else
                     server_model[attr_key] = attr
                   end

--- a/app/controllers/backbone_rails_store_controller.rb
+++ b/app/controllers/backbone_rails_store_controller.rb
@@ -384,8 +384,32 @@ class BackboneRailsStoreController < ApplicationController
     end
   end
 
+  def verify_before_destroy
+    response = {:can_destroy => true}
+    begin
+      klass = params[:railsClass].constantize
+      id = params[:id]
 
+      klass.transaction do
+        model = klass.find(id)
 
+        begin
+          model.destroy
+        rescue
+          response[:can_destroy] = false
+        end
+
+        raise ActiveRecord::Rollback
+      end
+
+    rescue Exception => exp
+      response = {errors: exp.errors}
+    end
+
+    respond_to do |format|
+      format.json { render json: response }
+    end
+  end
 
   private
 

--- a/app/controllers/backbone_rails_store_controller.rb
+++ b/app/controllers/backbone_rails_store_controller.rb
@@ -354,7 +354,7 @@ class BackboneRailsStoreController < ApplicationController
     end
 
     respond_to do |format|
-      format.json { render json: response }
+      format.json { render json: response.as_json }
     end
   end
 

--- a/backbone_rails_store.gemspec
+++ b/backbone_rails_store.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |s|
   s.files = Dir["app/**/*"] + Dir["vendor/**/*"] + Dir["lib/**/*"] + ["MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", ">= 3.1.0"
-  s.add_dependency('railties', '>= 3.1.0')
+#  s.add_dependency "rails", ">= 3.1.0"
+#  s.add_dependency('railties', '>= 3.1.0')
   s.add_dependency('coffee-script', '~> 2.2.0')
-  s.add_dependency('jquery-rails', '>= 2.1')
+#  s.add_dependency('jquery-rails', '>= 2.1')
   s.add_dependency('ejs', '~> 1.1.1')
 end

--- a/lib/backbone_rails_store.rb
+++ b/lib/backbone_rails_store.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'rails'
 
 module BackboneRailsStore

--- a/lib/backbone_rails_store/version.rb
+++ b/lib/backbone_rails_store/version.rb
@@ -1,4 +1,4 @@
 # -*- encoding : utf-8 -*-
 module BackboneRailsStore
-  VERSION = "1.0.16"
+  VERSION = "1.0.17"
 end

--- a/lib/backbone_rails_store/version.rb
+++ b/lib/backbone_rails_store/version.rb
@@ -1,4 +1,4 @@
 # -*- encoding : utf-8 -*-
 module BackboneRailsStore
-  VERSION = "1.0.17"
+  VERSION = "1.0.18"
 end

--- a/lib/backbone_rails_store/version.rb
+++ b/lib/backbone_rails_store/version.rb
@@ -1,3 +1,3 @@
 module BackboneRailsStore
-  VERSION = "1.0.12"
+  VERSION = "1.0.13"
 end

--- a/lib/backbone_rails_store/version.rb
+++ b/lib/backbone_rails_store/version.rb
@@ -1,4 +1,4 @@
 # -*- encoding : utf-8 -*-
 module BackboneRailsStore
-  VERSION = "1.0.14"
+  VERSION = "1.0.15"
 end

--- a/lib/backbone_rails_store/version.rb
+++ b/lib/backbone_rails_store/version.rb
@@ -1,4 +1,4 @@
 # -*- encoding : utf-8 -*-
 module BackboneRailsStore
-  VERSION = "1.0.15"
+  VERSION = "1.0.16"
 end

--- a/lib/backbone_rails_store/version.rb
+++ b/lib/backbone_rails_store/version.rb
@@ -1,4 +1,4 @@
 # -*- encoding : utf-8 -*-
 module BackboneRailsStore
-  VERSION = "1.0.18"
+  VERSION = "1.0.19"
 end

--- a/lib/backbone_rails_store/version.rb
+++ b/lib/backbone_rails_store/version.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module BackboneRailsStore
   VERSION = "1.0.13"
 end

--- a/lib/backbone_rails_store/version.rb
+++ b/lib/backbone_rails_store/version.rb
@@ -1,4 +1,4 @@
 # -*- encoding : utf-8 -*-
 module BackboneRailsStore
-  VERSION = "1.0.13"
+  VERSION = "1.0.14"
 end

--- a/routes.rb
+++ b/routes.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 ##
 # Backbone.RailsStore Routes Example file
 #

--- a/test/backbone_rails_store_test.rb
+++ b/test/backbone_rails_store_test.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'test_helper'
 
 class BackboneRailsStoreTest < ActiveSupport::TestCase

--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 class ApplicationController < ActionController::Base
   protect_from_forgery
 end

--- a/test/dummy/app/helpers/application_helper.rb
+++ b/test/dummy/app/helpers/application_helper.rb
@@ -1,2 +1,3 @@
+# -*- encoding : utf-8 -*-
 module ApplicationHelper
 end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'

--- a/test/dummy/config/boot.rb
+++ b/test/dummy/config/boot.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'rubygems'
 gemfile = File.expand_path('../../../../Gemfile', __FILE__)
 

--- a/test/dummy/config/environment.rb
+++ b/test/dummy/config/environment.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # Load the rails application
 require File.expand_path('../application', __FILE__)
 

--- a/test/dummy/config/environments/development.rb
+++ b/test/dummy/config/environments/development.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 Dummy::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb
 

--- a/test/dummy/config/environments/production.rb
+++ b/test/dummy/config/environments/production.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 Dummy::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb
 

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 Dummy::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb
 

--- a/test/dummy/config/initializers/backtrace_silencers.rb
+++ b/test/dummy/config/initializers/backtrace_silencers.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.

--- a/test/dummy/config/initializers/inflections.rb
+++ b/test/dummy/config/initializers/inflections.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format

--- a/test/dummy/config/initializers/mime_types.rb
+++ b/test/dummy/config/initializers/mime_types.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:

--- a/test/dummy/config/initializers/secret_token.rb
+++ b/test/dummy/config/initializers/secret_token.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # Be sure to restart your server when you modify this file.
 
 # Your secret key for verifying the integrity of signed cookies.

--- a/test/dummy/config/initializers/session_store.rb
+++ b/test/dummy/config/initializers/session_store.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # Be sure to restart your server when you modify this file.
 
 Dummy::Application.config.session_store :cookie_store, key: '_dummy_session'

--- a/test/dummy/config/initializers/wrap_parameters.rb
+++ b/test/dummy/config/initializers/wrap_parameters.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # Be sure to restart your server when you modify this file.
 #
 # This file contains settings for ActionController::ParamsWrapper which

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 Dummy::Application.routes.draw do
   # The priority is based upon order of creation:
   # first created -> highest priority.

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 


### PR DESCRIPTION
RailsModel.commit refeito de modo que os models belongs_to sempre são salvos depois dos has_many nos relacionamentos.

Precisa ser testado no caso do nome da classe no javascript for diferente do nome da classe no rails.
